### PR TITLE
build: add support for Facebook videos. As Facebook doesn't provide a…

### DIFF
--- a/angular-fluidVid.js
+++ b/angular-fluidVid.js
@@ -14,7 +14,7 @@ angular.module('tinacious.fluidVid', [])
         }
 
         if (!videoType) {
-          $log.error('Specify type, either \'youtube\' or \'vimeo\'');
+          $log.error('Specify type, either \'youtube\', \'vimeo\' or \'facebook\'');
         }
 
         // video code based on video type
@@ -27,7 +27,11 @@ angular.module('tinacious.fluidVid', [])
             case 'vimeo':
               videoCode = '<iframe src="http://player.vimeo.com/video/' + videoId + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
               break;
-            
+
+            case 'facebook':
+              videoCode = '<iframe src="https://www.facebook.com/plugins/video.php?href=' + videoId + '" width="400" height="400" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allowFullScreen="true"></iframe>';
+              break;
+
             default:
               $log.error('Sorry, the type "' + videoType + '" is not currently supported. Please use either \'youtube\' or \'vimeo\'');
           }


### PR DESCRIPTION
Add support for Facebook videos. As Facebook does not provide the video ID in it's embed code, we need to use the path that's supplied in the iframe embed link such as "https%3A%2F%2Fwww.facebook.com%2Ftheguardian%2Fvideos%2F563281880526246%2F&show_text=0&width=400" as the video-id.
